### PR TITLE
feat/improve-ci-release-workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   ci:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,11 @@ on:
       - "**"
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
   release:
+    needs: ci
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
- Make CI workflow reusable by adding workflow_call trigger
- Refactor release workflow to depend on CI workflow completion
- Eliminate code duplication between CI and release workflows
- Ensure release only happens after all CI checks pass

This ensures consistency between PR checks and release checks,
and follows the single responsibility principle.
