### PR TITLE
fix/avoid-duplicate-ci-on-tag-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags-ignore:
+      - "**"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
- Add tags-ignore to CI workflow to prevent triggering on tag pushes
- Release workflow already runs CI internally via workflow_call
- This eliminates redundant CI runs during release process

Resolves duplicate workflow execution issue when creating releases.
