### PR TITLE
fix/prevent-ci-on-tag-push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags-ignore:
-      - "**"
   pull_request:
     branches:
       - main
@@ -15,6 +13,7 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    if: github.ref_type != 'tag'
 
     strategy:
       matrix:


### PR DESCRIPTION
- Add explicit condition to skip CI when github.ref_type is 'tag'
- This ensures CI only runs on branch pushes and PRs
- Release workflow already handles CI execution via workflow_call
- Resolves issue where tags-ignore was not working as expected
